### PR TITLE
Fix support for multiple required domains

### DIFF
--- a/conf.environment.js
+++ b/conf.environment.js
@@ -84,7 +84,7 @@ if(modules.indexOf('google') >= 0) {
 
     // User must be a member of this domain to successfully authenticate. If an array
     // is listed, user may authenticate as a member of ANY of the domains.
-    requiredDomain: process.env.DOORMAN_GOOGLE_REQUIRED_DOMAIN
+    requiredDomain: process.env.DOORMAN_GOOGLE_REQUIRED_DOMAIN && process.env.DOORMAN_GOOGLE_REQUIRED_DOMAIN.split(',')
   };
 }
 


### PR DESCRIPTION
Multiple required domains are supported in the google module, but the configuration was not parsing the corresponding environment variable with a comma-separated format.
